### PR TITLE
Fix for ai_settings goals loaded as list(dict)

### DIFF
--- a/autogpt/utils.py
+++ b/autogpt/utils.py
@@ -134,4 +134,4 @@ def get_latest_bulletin() -> str:
 
 def remove_color_codes(s: str) -> str:
     ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-    return ansi_escape.sub("", s)
+    return ansi_escape.sub("", str(s))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -224,6 +224,7 @@ def test_remove_color_codes():
         remove_color_codes("\x1B[1m\x1B[31mError:\x1B[0m\x1B[31m file not found")
         == "Error: file not found"
     )
+    assert remove_color_codes({"I": "am a dict"}) == f"{{'I': 'am a dict'}}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix for ai_settings goals loaded as list(dict)

Some ai_settings formats can cause goals to load as list(dict)
not list(str)

Refactor code in utils.py to explicitly convert input type to string in
remove_color_codes() function.

- Updated remove_color_codes function to convert input argument
 to string type explicitly to avoid unexpected type errors.
- Test case added to check conversion of dict to string in
remove_color_codes function.